### PR TITLE
fix pubDate & support more zhihu users

### DIFF
--- a/morerss/zhihu.py
+++ b/morerss/zhihu.py
@@ -146,7 +146,7 @@ def post2rss(baseurl, post, *, digest=False, pic=None):
     link = url,
     guid = url,
     description = content,
-    pubDate = datetime.datetime.fromtimestamp(post['updated']),
+    pubDate = datetime.datetime.utcfromtimestamp(post['updated']),
     author = post['author']['name'],
   )
   return item

--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -37,6 +37,8 @@ class ZhihuAPI:
     headers = {
       'User-Agent': self.user_agent,
       'Authorization': 'oauth c3cef7c66a1843f8b3a9e6a1e3160e20', # hard-coded in js
+      'x-api-version': '3.0.40',
+      'x-udid': 'AMAiMrPqqQ2PTnOxAr5M71LCh-dIQ8kkYvw=',
     }
     res = await fetch_zhihu(url, headers = headers)
     return json.loads(res.body.decode('utf-8'))


### PR DESCRIPTION
1. `datetime.datetime.fromtimestamp` 得到的是没有时区的 datetime obj 。
偏偏这个 datetime obj 的时间还取决于本地时区。然后转成 rss 之后 pubDate 就有问题了（是未来的时间）。
总之，应该用 `utcfromtimestamp` 。
顺带一提：有些阅读器 (inoreader, ttrss) 不能处理未来的时间，inoreader 会把 post time 变成阅读器抓取的时间，ttrss也是这样，但是顺序会乱（ttrss很迷……）；
有些可以（miniflux）。

2. 有些用户主页要登录才能查看，添加两个参数来支持这些用户。具体信息不小心写到 commit 里了（