### PR TITLE
添加知乎用户的想法到 ZhihuStream 中

### DIFF
--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -204,6 +204,12 @@ def pin_content(pin):
     else:
       logger.warn('unknown type: %s', content['type'])
 
+  if 'origin_pin' in pin:
+    origin_pin = pin['origin_pin']
+    if not origin_pin['is_deleted']:
+      merged_content += '<a href="https://www.zhihu.com/pin/%s" target="_blank" rel="nofollow noreferrer">%s</a>' % (origin_pin['id'], origin_pin['author']['name']) + '：<br><br>'
+      merged_content += pin_content(origin_pin)
+
   return merged_content
 
 

--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -206,9 +206,13 @@ def pin_content(pin):
 
   if 'origin_pin' in pin:
     origin_pin = pin['origin_pin']
+
+    merged_content += '回复<a href="https://www.zhihu.com/people/%s" target="_blank" rel="nofollow noreferrer">%s</a>的<a href="https://www.zhihu.com/pin/%s" target="_blank" rel="nofollow noreferrer">想法</a>' % (origin_pin['author']['id'], origin_pin['author']['name'], origin_pin['id']) + '：<br><br>'
+
     if not origin_pin['is_deleted']:
-      merged_content += '<a href="https://www.zhihu.com/pin/%s" target="_blank" rel="nofollow noreferrer">%s</a>' % (origin_pin['id'], origin_pin['author']['name']) + '：<br><br>'
       merged_content += pin_content(origin_pin)
+    else:
+      merged_content += origin_pin['deleted_reason']
 
   return merged_content
 


### PR DESCRIPTION
知乎想法的 api v4 接口为 https://www.zhihu.com/api/v4/members/farseerfc/pins/ ，需要注意的是最后的那个 `/` 没有会出错。

想法的主要内容都在 `content` 这个 key 中，这个 content 的值是一个 dict 列表，其中每个 dict 都是想法的一部分内容，这些 dict 的的类型有 `text`，`link` 和 `image` 三种（可能还有我没发现的）。

每个想法还可以引用别人的想法，这个引用是保存在 `origin_pin` 这个 key 中。如果没有引用想法，就没有这个 key。还需要注意的是，引用的想法可能被删除了，这个表示在 `is_deleted` 这个 key 中。

上面就是我解析“想法”的大致思路。

然后我把这个思路集成到 `zhihu_stream.py` 中 `activities2rss` 这个函数中，和“文章”，“回答”一起推送。

我在 arch 上用 QuiteRSS 本地测试的效果大概如下

![image](https://user-images.githubusercontent.com/40143136/97514823-a3600800-19ca-11eb-81a6-b403675f3483.png)
