### PR TITLE
支持想法里视频的预览图

### DIFF
--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -273,6 +273,8 @@ def pin_content(pin):
       merged_content += '<a href="%s" target="_blank" rel="nofollow noreferrer">%s</a>' % (content['url'], content['title']) + '<br><br>'
     elif content['type'] == 'image':
       merged_content += '<img src="%s" data-rawwidth="%s" data-rawheight="%s">' % (content['url'], content['width'], content['height']) + '<br><br>'
+    elif content['type'] == 'video':
+      merged_content += '此处<a href="https://www.zhihu.com/video/%s">视频</a>预览图如下：<br><br><img src="%s" data-rawwidth="%s" data-rawheight="%s">' % (content['id'], content['cover_info']['thumbnail'], content['cover_info']['width'], content['cover_info']['height'])
     else:
       logger.warn('unknown type: %s', content['type'])
 
@@ -531,7 +533,9 @@ async def test():
 
 if __name__ == '__main__':
   import tornado.ioloop
-  from nicelogger import enable_pretty_logging
-  enable_pretty_logging('DEBUG')
+
+  # from nicelogger import enable_pretty_logging
+  # enable_pretty_logging('DEBUG')
+
   loop = tornado.ioloop.IOLoop.current()
   loop.run_sync(test)

--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -271,7 +271,6 @@ def pin_content(pin):
       merged_content += content['content'] + '<br><br>'
     elif content['type'] == 'link':
       merged_content += '<a href="%s" target="_blank" rel="nofollow noreferrer">%s</a>' % (content['url'], content['title']) + '<br><br>'
-      pass
     elif content['type'] == 'image':
       merged_content += '<img src="%s" data-rawwidth="%s" data-rawheight="%s">' % (content['url'], content['width'], content['height']) + '<br><br>'
     else:

--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -272,9 +272,9 @@ def pin_content(pin):
     elif content['type'] == 'link':
       merged_content += '<a href="%s" target="_blank" rel="nofollow noreferrer">%s</a>' % (content['url'], content['title']) + '<br><br>'
     elif content['type'] == 'image':
-      merged_content += '<img src="%s" data-rawwidth="%s" data-rawheight="%s">' % (content['url'], content['width'], content['height']) + '<br><br>'
+      merged_content += '<img src="%s">' % content['url'] + '<br><br>'
     elif content['type'] == 'video':
-      merged_content += '此处<a href="https://www.zhihu.com/video/%s">视频</a>预览图如下：<br><br><a href="https://www.zhihu.com/video/%s"><img src="%s" data-rawwidth="%s" data-rawheight="%s"></a>' % (content['id'], content['id'], content['cover_info']['thumbnail'], content['cover_info']['width'], content['cover_info']['height'])
+      merged_content += '此处<a href="https://www.zhihu.com/video/%s">视频</a>预览图如下：<br><br><a href="https://www.zhihu.com/video/%s"><img src="%s" ></a>' % (content['id'], content['id'], content['cover_info']['thumbnail'])
     else:
       logger.warn('unknown type: %s', content['type'])
 

--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -274,7 +274,7 @@ def pin_content(pin):
     elif content['type'] == 'image':
       merged_content += '<img src="%s">' % content['url'] + '<br><br>'
     elif content['type'] == 'video':
-      merged_content += '此处<a href="https://www.zhihu.com/video/%s">视频</a>预览图如下：<br><br><a href="https://www.zhihu.com/video/%s"><img src="%s" ></a>' % (content['id'], content['id'], content['cover_info']['thumbnail'])
+      merged_content += '此处<a href="https://www.zhihu.com/video/%s">视频</a>预览图如下：<br><br><a href="https://www.zhihu.com/video/%s"><img src="%s" ></a><br><br>' % (content['id'], content['id'], content['cover_info']['thumbnail'])
     else:
       logger.warn('unknown type: %s', content['type'])
 

--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -274,7 +274,7 @@ def pin_content(pin):
     elif content['type'] == 'image':
       merged_content += '<img src="%s" data-rawwidth="%s" data-rawheight="%s">' % (content['url'], content['width'], content['height']) + '<br><br>'
     elif content['type'] == 'video':
-      merged_content += '此处<a href="https://www.zhihu.com/video/%s">视频</a>预览图如下：<br><br><img src="%s" data-rawwidth="%s" data-rawheight="%s">' % (content['id'], content['cover_info']['thumbnail'], content['cover_info']['width'], content['cover_info']['height'])
+      merged_content += '此处<a href="https://www.zhihu.com/video/%s">视频</a>预览图如下：<br><br><a href="https://www.zhihu.com/video/%s"><img src="%s" data-rawwidth="%s" data-rawheight="%s"></a>' % (content['id'], content['id'], content['cover_info']['thumbnail'], content['cover_info']['width'], content['cover_info']['height'])
     else:
       logger.warn('unknown type: %s', content['type'])
 


### PR DESCRIPTION
在 https://github.com/lilydjwg/morerssplz/pull/34#issuecomment-723046656 基础上，我也试了试 `<![CDATA[some stuff]]>`，但是发现 `<![` 这些都被转义了。想不到别的什么办法，目前只支持了预览图的显示：


![image](https://user-images.githubusercontent.com/40143136/98495292-c667a300-2279-11eb-92f3-cf86bd64ffe7.png)
