### PR TITLE
支持收藏夹的全文输出

### DIFF
--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -462,7 +462,6 @@ async def collection2rss(id, pic=None):
   collection_contents = []
   for x in data['data']:
     x['content']['type'] = 'MEMBER_COLLECT_' + x['content']['type'].upper()
-    print(x['content']['type'])
     collection_contents.append(x['content'])
 
   while len(collection_contents) < 20 and page < 3:

--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -55,7 +55,7 @@ class ZhihuAPI:
     return data
 
   async def collection_contents(self, id):
-    url = 'collections/%s/contents' % id
+    url = 'collections/%s/items' % id
     query = {
       'desktop': 'True',
       'after_id': str(int(time.time())),
@@ -445,7 +445,7 @@ async def collection2rss(id, pic=None):
 
   page = 0
   data = await zhihu_api.collection_contents(id)
-  collection_contents = [x for x in data['data']]
+  collection_contents = [x['content'] for x in data['data']]
 
   while len(collection_contents) < 20 and page < 3:
     paging = data['paging']
@@ -455,7 +455,7 @@ async def collection2rss(id, pic=None):
     next_url = paging['next']
     data = await zhihu_api.get_json(next_url)
     collection_contents.extend(
-      x for x in data['data']
+      x['content'] for x in data['data']
     )
     page += 1
 


### PR DESCRIPTION
发现 `https://www.zhihu.com/api/v4/collections/312644462/items` 这个 api 有全文输出。

依云您在 https://github.com/lilydjwg/morerssplz/pull/36#issuecomment-720536628 这里的建议，需不需要应用到收藏夹里来呢？

> 原来放在作者栏里了呀。不过在「赞同」里还是放到更显著的位置比较好。通常的 RSS 源的作者信息没那么重要（都是同一个或者几个作者），但这个不一样。

目前是这样的：

![image](https://user-images.githubusercontent.com/40143136/99250169-3790f280-2846-11eb-9e91-e0425540c91b.png)
