### PR TITLE
Fix Zhihu topic after_id

### DIFF
--- a/morerss/zhihu_stream.py
+++ b/morerss/zhihu_stream.py
@@ -78,7 +78,6 @@ class ZhihuAPI:
       url = 'topics/%s/feeds/timeline_activity' % id
     query = {
       'desktop': 'True',
-      'after_id': str(int(time.time())),
       'limit': '7',
     }
     url += '?' + urlencode(query)


### PR DESCRIPTION
Addressing https://github.com/lilydjwg/morerssplz/issues/42

It seems that Zhihu has changed its Topics API.

A GET request without `after_id`:
```
https://www.zhihu.com/api/v4/topics/19611404/feeds/top_activity
```

now returns

```
{
    "paging": {
        "is_end": false,
        "totals": 74758,
        "next": "http://www.zhihu.com/api/v4/topics/19611404/feeds/top_activity?limit=7&after_id=7.00000",
        "is_start": true,
        "previous": "http://www.zhihu.com/api/v4/topics/19611404/feeds/top_activity?before_id=0&limit=7"
    },
```

Notice that `after_id` in Zhihu Topics response is now an **offset** of the post on the topics page. It is different from the Zhihu User API, which is a **timestamp**.

Removing this line seems to work:
```
'after_id': str(int(time.time())),
```

Zhihu Topics API returns `after_id`  in the `paging.next` URL by default, so morerssplz can follow it automatically.